### PR TITLE
EVM384 v9

### DIFF
--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -151,6 +151,21 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
         case OP_PC:
             instr.arg.number = code_pos - code - 1;
             break;
+
+        case 0xc0:
+        {
+            constexpr auto imm_size = 16;
+
+            auto& imm_object = analysis.push_values.emplace_back();
+            const auto imm_bytes = intx::as_bytes(imm_object);
+
+            // FIXME: Code bounds are not checked.
+            std::copy_n(code_pos, imm_size, imm_bytes);
+            code_pos += imm_size;
+
+            instr.arg.push_value = &imm_object;
+            break;
+        }
         }
 
         // If this is a terminating instruction or the next instruction is a JUMPDEST.

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -154,6 +154,7 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
 
         case 0xc0:
         case 0xc1:
+        case 0xc2:
         {
             constexpr auto imm_size = 16;
 

--- a/lib/evmone/analysis.cpp
+++ b/lib/evmone/analysis.cpp
@@ -153,6 +153,7 @@ code_analysis analyze(evmc_revision rev, const uint8_t* code, size_t code_size) 
             break;
 
         case 0xc0:
+        case 0xc1:
         {
             constexpr auto imm_size = 16;
 

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1256,14 +1256,13 @@ void print_bytes384(uint8_t* bytes)
 
 const instruction* op_addmod384(const instruction* instr, execution_state& state) noexcept
 {
-    const auto arg = state.stack.pop();
-    const auto params = intx::as_bytes(arg);
+    const auto params = intx::as_bytes(*instr->arg.push_value);
 
-
-    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
-    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
-    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
-    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    // Instruction immediate value: 4x uint32 little-endian indices.
+    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
+    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
+    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
 
     const auto max_memory_index =
         std::max(std::max(x_offset, y_offset), std::max(out_offset, mod_offset));
@@ -1519,7 +1518,7 @@ constexpr op_table create_op_table_istanbul() noexcept
     table[OP_SELFBALANCE] = {op_selfbalance, 5, 0, 1};
     table[OP_SLOAD] = {op_sload, 800, 1, 0};
 
-    table[0xc0] = {op_addmod384, 8, 1, -1};
+    table[0xc0] = {op_addmod384, 8, 0, 0};
     table[0xc1] = {op_submod384, 8, 1, -1};
     table[0xc2] = {op_mulmodmont384, 24, 1, -1};
     return table;

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1322,13 +1322,13 @@ void print_bytes256(uint8_t* bytes)
 
 const instruction* op_mulmodmont384(const instruction* instr, execution_state& state) noexcept
 {
-    const auto params = intx::as_bytes(state.stack[0]);
-    state.stack.pop();
+    const auto params = intx::as_bytes(*instr->arg.push_value);
 
-    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
-    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
-    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
-    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    // Instruction immediate value: 4x uint32 little-endian indices.
+    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
+    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
+    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
 
     const auto max_memory_index =
         std::max(std::max(x_offset, y_offset), std::max(out_offset, mod_offset));
@@ -1520,7 +1520,7 @@ constexpr op_table create_op_table_istanbul() noexcept
 
     table[0xc0] = {op_addmod384, 8, 0, 0};
     table[0xc1] = {op_submod384, 8, 0, 0};
-    table[0xc2] = {op_mulmodmont384, 24, 1, -1};
+    table[0xc2] = {op_mulmodmont384, 24, 0, 0};
     return table;
 }
 

--- a/lib/evmone/instructions.cpp
+++ b/lib/evmone/instructions.cpp
@@ -1283,13 +1283,13 @@ const instruction* op_addmod384(const instruction* instr, execution_state& state
 
 const instruction* op_submod384(const instruction* instr, execution_state& state) noexcept
 {
-    const auto params = intx::as_bytes(state.stack[0]);
-    state.stack.pop();
+    const auto params = intx::as_bytes(*instr->arg.push_value);
 
-    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
-    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
-    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
-    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    // Instruction immediate value: 4x uint32 little-endian indices.
+    const auto out_offset = *reinterpret_cast<const uint32_t*>(&params[0]);
+    const auto x_offset = *reinterpret_cast<const uint32_t*>(&params[4]);
+    const auto y_offset = *reinterpret_cast<const uint32_t*>(&params[8]);
+    const auto mod_offset = *reinterpret_cast<const uint32_t*>(&params[12]);
 
     const auto max_memory_index =
         std::max(std::max(x_offset, y_offset), std::max(out_offset, mod_offset));
@@ -1519,7 +1519,7 @@ constexpr op_table create_op_table_istanbul() noexcept
     table[OP_SLOAD] = {op_sload, 800, 1, 0};
 
     table[0xc0] = {op_addmod384, 8, 0, 0};
-    table[0xc1] = {op_submod384, 8, 1, -1};
+    table[0xc1] = {op_submod384, 8, 0, 0};
     table[0xc2] = {op_mulmodmont384, 24, 1, -1};
     return table;
 }

--- a/test/unittests/evm384_test.cpp
+++ b/test/unittests/evm384_test.cpp
@@ -50,9 +50,10 @@ TEST_F(evm386, submod_1)
 TEST_F(evm386, mulmod_garbage)
 {
     rev = EVMC_ISTANBUL;
-    const auto indices_packed = push("00000000000000000000003000000060");  // 0,0,48,96
+    // Instruction immediate value: 4x uint32 little-endian indices: 0,0,48,96.
+    const auto indices_packed = bytecode{"00000000000000003000000060000000"};
 
-    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + indices_packed + "c2" + ret(0, 48);
+    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + "c2" + indices_packed + ret(0, 48);
     execute(code,
         // clang-format off
         "2d68c6c3a8b1f5a1077ef949836ddc178987ad09e0723f3d9a4aa95f50661652cb9a677b35e122903028f807272c104a"
@@ -61,7 +62,7 @@ TEST_F(evm386, mulmod_garbage)
         "ffffffffffffffff"  // garbage inv
         // clang-format on
     );
-    EXPECT_GAS_USED(EVMC_SUCCESS, 74);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 71);
     EXPECT_EQ(hex(bytes_view(result.output_data, result.output_size)),
         "b0f9fdbafea7416d7d306f04e96da1f87f72296a25bdb9263fbd57a66982d129208bf5683e3191274250b21744"
         "c12997");

--- a/test/unittests/evm384_test.cpp
+++ b/test/unittests/evm384_test.cpp
@@ -10,9 +10,10 @@ using evm386 = evm;
 TEST_F(evm386, addmod_1)
 {
     rev = EVMC_ISTANBUL;
-    const auto indices_packed = push("00000000000000000000003000000060");  // 0,0,48,96
+    // Instruction immediate value: 4x uint32 little-endian indices: 0,0,48,96.
+    const auto indices_packed = bytecode{"00000000000000003000000060000000"};
 
-    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + indices_packed + "c0" + ret(0, 48);
+    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + "c0" + indices_packed + ret(0, 48);
     execute(code,
         // clang-format off
         "3c119b3934156e9d9a495378725bb6c7fdcd12784743919063f5a383d2d2af117e025fdb0fb03fa723a62a4d6d968d2b"
@@ -20,7 +21,7 @@ TEST_F(evm386, addmod_1)
         "ec1e91ae1c738c60602becdaa2c68049efc48e8efa17054cdfb487bd3ccf137fe7e517dbee90eef07123d231ea794fa5"
         // clang-format on
     );
-    EXPECT_GAS_USED(EVMC_SUCCESS, 58);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 55);
     EXPECT_EQ(hex(bytes_view(result.output_data, result.output_size)),
         "2d68c6c3a8b1f5a1077ef949836ddc178987ad09e0723f3d9a4aa95f50661652cb9a677b35e122903028f80727"
         "2c104a");

--- a/test/unittests/evm384_test.cpp
+++ b/test/unittests/evm384_test.cpp
@@ -30,9 +30,10 @@ TEST_F(evm386, addmod_1)
 TEST_F(evm386, submod_1)
 {
     rev = EVMC_ISTANBUL;
-    const auto indices_packed = push("00000000000000000000003000000060");  // 0,0,48,96
+    // Instruction immediate value: 4x uint32 little-endian indices: 0,0,48,96.
+    const auto indices_packed = bytecode{"00000000000000003000000060000000"};
 
-    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + indices_packed + "c1" + ret(0, 48);
+    const auto code = calldatacopy(0, 0, OP_CALLDATASIZE) + "c1" + indices_packed + ret(0, 48);
     execute(code,
         // clang-format off
        "2d68c6c3a8b1f5a1077ef949836ddc178987ad09e0723f3d9a4aa95f50661652cb9a677b35e122903028f807272c104a"
@@ -40,7 +41,7 @@ TEST_F(evm386, submod_1)
        "ec1e91ae1c738c60602becdaa2c68049efc48e8efa17054cdfb487bd3ccf137fe7e517dbee90eef07123d231ea794fa5"
         // clang-format on
     );
-    EXPECT_GAS_USED(EVMC_SUCCESS, 58);
+    EXPECT_GAS_USED(EVMC_SUCCESS, 55);
     EXPECT_EQ(hex(bytes_view(result.output_data, result.output_size)),
         "3c119b3934156e9d9a495378725bb6c7fdcd12784743919063f5a383d2d2af117e025fdb0fb03fa723a62a4d6d"
         "968d2b");


### PR DESCRIPTION
The EVM384 v9: instructions' memory indices are provided by 16-byte immediate value after the instruction opcode. These are 4 `uint32` little-endian values.

The indices are not little-endian to have minimal instructions implementations change. Previously they were big-endian because were provided by PUSH16 which did byte-swap.